### PR TITLE
Update worker approach and other small changes

### DIFF
--- a/BasicBrowser.java
+++ b/BasicBrowser.java
@@ -18,78 +18,10 @@ import java.net.URL;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
 public class BasicBrowser extends JPanel {
-
-    interface RunnableFutureFactory<T> {
-        boolean createFuture(Supplier<T> doInBackground, Consumer<T> done, Consumer<String> runFinally);
-        boolean runFuture();
-        boolean clearFuture();
-        void tryCancellingFuture();
-    }
-
-    static class SwingWorkerFactory<T, V> implements RunnableFutureFactory<T> {
-        SwingWorker<T, V> worker;
-        SwingWorkerFactory() {
-            worker = null;
-        }
-
-        @Override
-        public boolean runFuture() {
-            if (worker == null) {
-                return false;
-            }
-            worker.execute();
-            return true;
-        }
-
-        @Override
-        public boolean clearFuture() {
-            if (worker == null) {
-                return false;
-            }
-            worker = null;
-            return true;
-        }
-
-        @Override
-        public void tryCancellingFuture() {
-            if (worker != null) {
-                worker.cancel(true);
-                worker = null;
-            }
-        }
-
-        @Override
-        public boolean createFuture(Supplier<T> doInBackground, Consumer<T> done, Consumer<String> runFinally) {
-            if (worker != null) {
-                return false;
-            }
-            worker = new SwingWorker<>() {
-                @Override
-                protected T doInBackground() {
-                    return doInBackground.get();
-                }
-
-                @Override
-                public void done() {
-                    String error = "";
-                    try {
-                        done.accept(get());
-                    } catch (InterruptedException | ExecutionException e) {
-                        error = e.toString();
-                    } finally {
-                        runFinally.accept(error);
-                    }
-                }
-            };
-            return true;
-        }
-    }
-
     static final String titleStr = "Basic Browser";
     static final String navigationBarStr = "Navigation Bar";
     static final String bookmarksBarStr = "Bookmarks Bar";
@@ -116,6 +48,7 @@ public class BasicBrowser extends JPanel {
     static final String memoryStr = "memory (MB) used %d, total %d, free %d, max %d";
     static final String urlTookStr = "Url |%s| took %s seconds to load.";
     static final String exceptionStr = "Exception |%s| for url |%s|.";
+    static final String futureExistsErrorStr = "Cannot update url |%s| at index %d because previous update not done.";
     static final String[] addRemoveStrings = {"Add/Remove A", "Add/Remove B", "Add/Remove C"};
     static final String[] bookmarkKeys = {"bookmarksA", "bookmarksB", "bookmarksC"};
     static final int urlColumns = 80;
@@ -133,11 +66,11 @@ public class BasicBrowser extends JPanel {
     ArrayList<HtmlTab> tabs;
     Deque<HtmlTab> closedTabs;
     Preferences preferences;
-    RunnableFutureFactory<String[]> futureFactory;
     LinkedList<Preferences> bookmarkPreferences;
     String[] quickSearches;
     JButton back, forward, reload, newTab, closeTab, openLastClosedTab, changeSearch;
     JButton[] addRemove;
+    boolean[] addRemoveIsRunning;
     LinkedList<JComboBox<String>> bookmarkBoxes;
     int iCurrentTab;
 
@@ -153,8 +86,7 @@ public class BasicBrowser extends JPanel {
 
     static void startGui() throws MalformedURLException, BackingStoreException {
         JFrame frame = new JFrame(titleStr);
-        frame.add(new BasicBrowser(Preferences.userRoot().node(BasicBrowser.class.getName()),
-                new SwingWorkerFactory<String[], Void>(), defaultMaxHistoryCount));
+        frame.add(new BasicBrowser(Preferences.userRoot().node(BasicBrowser.class.getName()), defaultMaxHistoryCount));
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setSize(new Dimension(defaultWidth, defaultHeight));
         frame.setLocationRelativeTo(null);
@@ -162,11 +94,10 @@ public class BasicBrowser extends JPanel {
     }
 
     static void log(String s) {
-        // System.out.println(s);
+        // System.out.println(Thread.currentThread() + " " + s);
     }
 
-    BasicBrowser(Preferences prefs, RunnableFutureFactory<String[]> factory, int historyCount)
-            throws MalformedURLException, BackingStoreException {
+    BasicBrowser(Preferences prefs, int historyCount) throws MalformedURLException, BackingStoreException {
         super(new BorderLayout());
 
         JPanel top = new JPanel(new GridLayout(0, 1));
@@ -192,12 +123,13 @@ public class BasicBrowser extends JPanel {
         navigationBar.add(urlField);
         bookmarksBar = newToolBar(bookmarksBarStr, top);
         preferences = prefs;
-        futureFactory = factory;
         loadPreferences();
         addRemove = new JButton[addRemoveStrings.length];
+        addRemoveIsRunning = new boolean[addRemoveStrings.length];
         for (int i = 0; i < addRemoveStrings.length; i++) {
             addRemove[i] = newButton(addRemoveStrings[i], KeyEvent.VK_D + i,
                     KeyEvent.CTRL_DOWN_MASK, bookmarksBar, this::addOrRemoveEvent);
+            addRemoveIsRunning[i] = false;
             bookmarksBar.add(bookmarkBoxes.get(i));
         }
 
@@ -286,19 +218,18 @@ public class BasicBrowser extends JPanel {
     void addTab() {
         HtmlTab tab = new HtmlTab(urlField, statusField, tabsPane,
                 (URL url) -> { addTab(); urlField.setText(url.toString()); urlUpdate(url.toString()); },
-                futureFactory, maxHistoryCount);
+                maxHistoryCount);
         addTab(tab);
     }
     void addTab(HtmlTab tab) {
         int index = tabs.size();
-        log("addTab at " + index);
+        log("addTab " + index);
         tabs.add(tab);
         tabsPane.addTab(tab.getTitle(), tab.scrollPane);
         if (index < mnemonicCount) {
             tabsPane.setMnemonicAt(index, KeyEvent.VK_1 + index);
         }
         tabsPane.setSelectedIndex(index);
-        log("Called setSelectedIndex " + index);
     }
 
     void openLastClosedTab() {
@@ -418,7 +349,6 @@ public class BasicBrowser extends JPanel {
     void addOrRemoveEvent(ActionEvent event) {
         String urlString = urlField.getText();
         if (!isUrl(urlString)) {
-            log("not a url: " + urlString);
             return;
         }
         String command = event.getActionCommand();
@@ -427,7 +357,8 @@ public class BasicBrowser extends JPanel {
             if (command.equals(addRemoveStrings[i])) {
                 var box = bookmarkBoxes.get(i);
                 Preferences bookmarkNode = bookmarkPreferences.get(i);
-                log(i + " match index for " + command);
+                log("box " + i);
+                addRemoveIsRunning[i] = true;
                 try {
                     URL url = new URL(urlString);
                     String match = null;
@@ -439,12 +370,12 @@ public class BasicBrowser extends JPanel {
                         }
                     }
                     if (match != null) {
-                        log(urlString + " url results in removing bookmark ");
+                        log("remove " + urlString);
                         box.removeItem(urlString);
                         bookmarkNode.remove(url.toString());
                     } else {
                         String title = tabsPane.getTitleAt(iCurrentTab);
-                        log(urlString + " url results in adding bookmark " + title);
+                        log("add " + urlString);
                         box.removeItemAt(box.getItemCount() - 1); // remove openALlStr and add after to be at end
                         box.addItem(urlString);
                         box.addItem(openAllStr);
@@ -452,6 +383,8 @@ public class BasicBrowser extends JPanel {
                     }
                 } catch (MalformedURLException e) {
                     statusField.setText(exceptionStr.formatted(e.toString(), urlString));
+                } finally {
+                    addRemoveIsRunning[i] = false;
                 }
             }
         }
@@ -464,16 +397,19 @@ public class BasicBrowser extends JPanel {
             JComboBox<String> box = bookmarkBoxes.get(i);
             if (source == box) {
                 String selected = box.getItemAt(box.getSelectedIndex());
-                if (selected == null) {
+                if (addRemoveIsRunning[i] || selected == null) {
+                    log("return");
                     return; // called from addOrRemoveEvent when change by adding/deleting. Don't do anything.
                 }
-                log(i + " index has selected " + selected);
+                log(i + " " + selected);
                 if (selected.equals(openAllStr)) {
                     log("Open all");
                     for (int iEntry = 0; iEntry < (box.getItemCount() - 1); iEntry++) {
                         addTab();
                         int index = tabs.size() - 1;
-                        tabs.get(index).urlUpdate(box.getItemAt(iEntry), index);
+                        String url = box.getItemAt(iEntry);
+                        urlField.setText(url);
+                        tabs.get(index).urlUpdate(url, index);
                     }
                 } else {
                     log("Open one");
@@ -503,10 +439,10 @@ public class BasicBrowser extends JPanel {
         JEditorPane editorPane;
         JScrollPane scrollPane;
         Consumer<URL> addTabWithUrl;
-        RunnableFutureFactory<String[]> futureFactory;
+        // RunnableFutureFactory<String[]> futureFactory;
+        SwingWorker<String[], Void> future;
 
-        HtmlTab(JTextField uf, JTextField sf, JTabbedPane tp, Consumer<URL> addTabWithUrlLambda,
-                RunnableFutureFactory<String[]> factory, int historyCount) {
+        HtmlTab(JTextField uf, JTextField sf, JTabbedPane tp, Consumer<URL> addTabWithUrlLambda, int historyCount) {
             history = new LinkedList<>();
             history.add("");
             maxHistoryCount = historyCount;
@@ -516,7 +452,8 @@ public class BasicBrowser extends JPanel {
             statusField = sf;
             tabsPane = tp;
             addTabWithUrl = addTabWithUrlLambda;
-            futureFactory = factory;
+            //futureFactory = factory;
+            future = null;
             kit = new HTMLEditorKit();
             kit.setAutoFormSubmission(false);
             editorPane = new JEditorPane("text/html", "");
@@ -536,15 +473,21 @@ public class BasicBrowser extends JPanel {
         }
 
         void setUrl(String newUrl) {
+            log("setUrl iH %d newUrl %s old h %s".formatted(iHistory, newUrl, Arrays.toString(history.toArray())));
             history.set(iHistory, newUrl);
-            log("setUrl iH %d h %s".formatted(iHistory, Arrays.toString(history.toArray())));
+            log("done setUrl iH %d new h %s".formatted(iHistory, Arrays.toString(history.toArray())));
         }
 
         void tryStoppingUpdater() {
-            futureFactory.tryCancellingFuture();
+            if (future != null) {
+                log("tryStoppingUpdater");
+                future.cancel(true);
+                future = null;
+            }
         }
 
         static String[] updaterDoInBackground(String url) {
+            log("updaterDoInBackground " + url);
             String[] result = {"", "", ""};
             long t0 = System.nanoTime();
             try {
@@ -567,6 +510,8 @@ public class BasicBrowser extends JPanel {
         }
 
         void updaterDone(String url, int index, String[] text) {
+            log("updaterDone url |%s| index %d text sizes %d %d %d".formatted(
+                    url, index, text[0].length(), text[1].length(), text[2].length()));
             String body = text[1];
             if (body.isEmpty()) {
                 statusField.setText(text[0]);
@@ -574,26 +519,47 @@ public class BasicBrowser extends JPanel {
                 title = text[0];
                 tabsPane.setTitleAt(index, title);
                 editorPane.setText(body);
-                log(title + " done SwingWorker " + body.length());
                 editorPane.setCaretPosition(0);
                 statusField.setText(String.format(urlTookStr, url, text[2]));
             }
         }
 
         void updaterRunFinally(String url, String error) {
-            futureFactory.clearFuture();
+            log("updaterRunFinally url |%s| error |%s|".formatted(url, error));
             if (error != null && !error.isEmpty()) {
                 statusField.setText(String.format(exceptionStr, error, url));
             }
+            future = null;
         }
 
         void urlUpdate(String url, int index) {
+            log("urlUpdate %s %d".formatted(url, index));
+            if (future != null) {
+                String error = futureExistsErrorStr.formatted(url, index);
+                log(error);
+                statusField.setText(error);
+                return;
+            }
             setUrl(url);
-            log(url + " urlUpdate " + index);
-            futureFactory.createFuture( () -> updaterDoInBackground(url),
-                    (text) -> updaterDone(url, index, text),
-                    (error) -> updaterRunFinally(url, error));
-            futureFactory.runFuture();
+            future = new SwingWorker<>() {
+                @Override
+                protected String[] doInBackground() {
+                    return updaterDoInBackground(url);
+                }
+
+                @Override
+                public void done() {
+                    String error = "";
+                    try {
+                        updaterDone(url, index, get());
+                    } catch (InterruptedException | ExecutionException e) {
+                        error = e.toString();
+                    } finally {
+                        updaterRunFinally(url, error);
+                    }
+                }
+            };
+            future.execute();
         }
 
         void goBack() {
@@ -624,7 +590,7 @@ public class BasicBrowser extends JPanel {
                 String urlString = url.toString();
                 if (event.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
                     boolean controlDown = event.getInputEvent().isControlDown();
-                    log(controlDown + "controlDown, url: " + url);
+                    log("hyperlinkUpdate url %s controlDown %s".formatted(url, controlDown));
                     if (controlDown) {
                         addTabWithUrl.accept(url);
                     } else {

--- a/BasicBrowserTest.java
+++ b/BasicBrowserTest.java
@@ -58,7 +58,7 @@ class BasicBrowserTest {
                 String url = "C:\\Users\\Name\\Downloads\\slashdot2.htm";
                 browser.urlField.setText(url);
                 browser.urlUpdate(url);
-                var worker = tab1.future;
+                var worker = tab1.worker;
                 if (worker != null) {
                     worker.run();
                 }
@@ -68,7 +68,7 @@ class BasicBrowserTest {
                 assertEquals(0, browser.iCurrentTab);
                 assertEquals("", browser.urlField.getText());
                 browser.openLastClosedTab();
-                worker = browser.tabs.get(1).future;
+                worker = browser.tabs.get(1).worker;
                 if (worker != null) {
                     worker.run();
                 }
@@ -103,7 +103,7 @@ class BasicBrowserTest {
                         new MouseEvent(source, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
                                 0, 50, 50, 1, false));
                 tab.hyperlinkUpdate(event);
-                var worker = tab.future;
+                var worker = tab.worker;
                 if (worker != null) {
                     worker.run();
                 }
@@ -121,7 +121,7 @@ class BasicBrowserTest {
                         new MouseEvent(source, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
                                 KeyEvent.CTRL_DOWN_MASK, 50, 50, 1, false));
                 tab.hyperlinkUpdate(event);
-                worker = tab.future;
+                worker = tab.worker;
                 if (worker != null) {
                     worker.run();
                 }
@@ -184,7 +184,7 @@ class BasicBrowserTest {
                         new MouseEvent(source, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
                                 0, 50, 50, 1, false));
                 tab.hyperlinkUpdate(event);
-                var worker = tab.future;
+                var worker = tab.worker;
                 if (worker != null) {
                     worker.run();
                 }
@@ -199,7 +199,7 @@ class BasicBrowserTest {
                         new MouseEvent(source, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
                                 0, 50, 50, 1, false));
                 tab.hyperlinkUpdate(event);
-                worker = tab.future;
+                worker = tab.worker;
                 if (worker != null) {
                     worker.run();
                 }
@@ -212,7 +212,7 @@ class BasicBrowserTest {
                         new MouseEvent(source, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
                                 0, 50, 50, 1, false));
                 tab.hyperlinkUpdate(event);
-                worker = tab.future;
+                worker = tab.worker;
                 if (worker != null) {
                     worker.run();
                 }
@@ -220,28 +220,28 @@ class BasicBrowserTest {
                 assertEquals(url3, browser.urlField.getText());
                 assertEquals(2, tab.iHistory);
                 tab.goBack();
-                worker = tab.future;
+                worker = tab.worker;
                 if (worker != null) {
                     worker.run();
                 }
                 assertEquals(url2, browser.urlField.getText());
                 assertEquals(1, tab.iHistory);
                 tab.goForward();
-                worker = tab.future;
+                worker = tab.worker;
                 if (worker != null) {
                     worker.run();
                 }
                 assertEquals(url3, browser.urlField.getText());
                 assertEquals(2, tab.iHistory);
                 tab.goBack();
-                worker = tab.future;
+                worker = tab.worker;
                 if (worker != null) {
                     worker.run();
                 }
                 assertEquals(url2, browser.urlField.getText());
                 assertEquals(1, tab.iHistory);
                 tab.goBack();
-                worker = tab.future;
+                worker = tab.worker;
                 if (worker != null) {
                     worker.run();
                 }
@@ -252,7 +252,7 @@ class BasicBrowserTest {
                         new MouseEvent(source, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
                                 0, 50, 50, 1, false));
                 tab.hyperlinkUpdate(event);
-                worker = tab.future;
+                worker = tab.worker;
                 if (worker != null) {
                     worker.run();
                 }
@@ -383,7 +383,7 @@ class BasicBrowserTest {
                 // Open bookmark
                 System.out.println("Will open a bookmark");
                 bookmarkBox.setSelectedItem(url1); // will trigger openBookmarkEvent(url1)
-                var worker = browser.tabs.get(0).future;
+                var worker = browser.tabs.get(0).worker;
                 if (worker != null) {
                     worker.run();
                 }
@@ -396,11 +396,11 @@ class BasicBrowserTest {
                 System.out.println("Will open all bookmarks");
                 bookmarkBox.setSelectedIndex(bookmarkBox.getItemCount() - 1); // will trigger openBookmarkEvent(openAll)
                 assertEquals(BasicBrowser.openAllStr, bookmarkBox.getSelectedItem());
-                worker = browser.tabs.get(1).future;
+                worker = browser.tabs.get(1).worker;
                 if (worker != null) {
                     worker.run();
                 }
-                worker = browser.tabs.get(2).future;
+                worker = browser.tabs.get(2).worker;
                 if (worker != null) {
                     worker.run();
                 }
@@ -434,7 +434,7 @@ class BasicBrowserTest {
                 tab.urlUpdate("http://localhost:8000/a", 0);
                 String url = "http://localhost:8001/a";
                 tab.urlUpdate(url, 0);
-                assertEquals(BasicBrowser.futureExistsErrorStr.formatted(url, 0), browser.statusField.getText());
+                assertEquals(BasicBrowser.workerExistsErrorStr.formatted(url, 0), browser.statusField.getText());
             } catch (MalformedURLException | BackingStoreException e) {
                 e.printStackTrace();
             }

--- a/BasicBrowserTest.java
+++ b/BasicBrowserTest.java
@@ -7,60 +7,19 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.prefs.BackingStoreException;
 
+import static java.lang.Thread.sleep;
 import static org.junit.jupiter.api.Assertions.*;
 
 class BasicBrowserTest {
-    static class ImmediateRunFactory<T> implements BasicBrowser.RunnableFutureFactory<T> {
-        boolean hasMethods;
-        Supplier<T> doInBackground;
-        Consumer<T> done;
-        Consumer<String> runFinally;
-
-        ImmediateRunFactory() {
-            hasMethods = false;
-        }
-
-        @Override
-        public boolean createFuture(Supplier<T> doInBackground, Consumer<T> done, Consumer<String> runFinally) {
-            System.out.println("createFuture " + hasMethods);
-            assertFalse(hasMethods);
-            hasMethods = true;
-            this.doInBackground = doInBackground;
-            this.done = done;
-            this.runFinally = runFinally;
-            return true;
-        }
-
-        @Override
-        public boolean runFuture() {
-            System.out.println("runFuture " + hasMethods);
-            assertTrue(hasMethods);
-            done.accept(doInBackground.get());
-            runFinally.accept("");
-            return true;
-        }
-
-        @Override
-        public boolean clearFuture() {
-            System.out.println("clearFuture " + hasMethods);
-            assertTrue(hasMethods);
-            hasMethods = false;
-            return true;
-        }
-
-        @Override
-        public void tryCancellingFuture() {
-        }
-    }
-
     final static String emptyHtml = """
             <html>\r
               <head>\r
@@ -82,8 +41,7 @@ class BasicBrowserTest {
     void testTabs() throws InvocationTargetException, InterruptedException {
         SwingUtilities.invokeAndWait(() -> {
             try {
-                BasicBrowser browser = new BasicBrowser(
-                        new MockPreferences(), new ImmediateRunFactory<>(), 2);
+                BasicBrowser browser = new BasicBrowser(new MockPreferences(), 2);
                 assertEquals(1, browser.tabs.size());
                 browser.closeTab();
                 assertEquals(1, browser.tabs.size());
@@ -91,24 +49,35 @@ class BasicBrowserTest {
                 assertEquals(2, browser.tabs.size());
                 assertEquals(1, browser.iCurrentTab);
                 assertEquals("", browser.urlField.getText());
-                assertEquals(emptyHtml, browser.tabs.get(1).editorPane.getText());
+                BasicBrowser.HtmlTab tab1 = browser.tabs.get(1);
+                assertEquals(emptyHtml, tab1.editorPane.getText());
                 browser.urlUpdate("");
-                assertEquals(emptyHtml, browser.tabs.get(1).editorPane.getText());
+                assertEquals(emptyHtml, tab1.editorPane.getText());
                 // Going to a url consists of filling the urlField and then its action event calls
                 // urlUpdate with the contents. Mimic that here.
                 String url = "C:\\Users\\Name\\Downloads\\slashdot2.htm";
                 browser.urlField.setText(url);
                 browser.urlUpdate(url);
-                assertNotEquals(emptyHtml, browser.tabs.get(1).editorPane.getText());
+                var worker = tab1.future;
+                if (worker != null) {
+                    worker.run();
+                }
+                assertNotEquals(emptyHtml, tab1.editorPane.getText());
                 browser.closeTab();
                 assertEquals(1, browser.tabs.size());
                 assertEquals(0, browser.iCurrentTab);
                 assertEquals("", browser.urlField.getText());
                 browser.openLastClosedTab();
+                worker = browser.tabs.get(1).future;
+                if (worker != null) {
+                    worker.run();
+                }
+                assertNotEquals(emptyHtml, browser.tabs.get(1).editorPane.getText());
                 assertEquals(2, browser.tabs.size());
                 assertEquals(1, browser.iCurrentTab);
                 assertEquals(url, browser.urlField.getText());
                 browser.openLastClosedTab();
+                assertEquals(BasicBrowser.noLastCloseTabsStr, browser.statusField.getText());
                 assertNotEquals("", browser.tabs.get(1).editorPane.getText());
                 assertEquals(2, browser.tabs.size());
                 assertEquals(1, browser.iCurrentTab);
@@ -124,8 +93,7 @@ class BasicBrowserTest {
     void testFollowingLinks() throws InvocationTargetException, InterruptedException {
         SwingUtilities.invokeAndWait(() -> {
             try {
-                BasicBrowser browser = new BasicBrowser(
-                        new MockPreferences(), new ImmediateRunFactory<>(), 2);
+                BasicBrowser browser = new BasicBrowser(new MockPreferences(), 2);
                 BasicBrowser.HtmlTab tab = browser.tabs.get(0);
                 Component source = tab.editorPane;
                 Element sourceElement = tab.kit.createDefaultDocument().getDefaultRootElement();
@@ -135,6 +103,10 @@ class BasicBrowserTest {
                         new MouseEvent(source, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
                                 0, 50, 50, 1, false));
                 tab.hyperlinkUpdate(event);
+                var worker = tab.future;
+                if (worker != null) {
+                    worker.run();
+                }
                 assertEquals(url, browser.urlField.getText());
                 assertEquals(1, browser.tabs.size());
                 assertEquals(0, browser.iCurrentTab);
@@ -149,6 +121,10 @@ class BasicBrowserTest {
                         new MouseEvent(source, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
                                 KeyEvent.CTRL_DOWN_MASK, 50, 50, 1, false));
                 tab.hyperlinkUpdate(event);
+                worker = tab.future;
+                if (worker != null) {
+                    worker.run();
+                }
                 assertEquals(url, browser.urlField.getText());
                 assertEquals(2, browser.tabs.size());
                 assertEquals(1, browser.iCurrentTab);
@@ -167,8 +143,7 @@ class BasicBrowserTest {
     void testHoverOverLinks() throws InvocationTargetException, InterruptedException {
         SwingUtilities.invokeAndWait(() -> {
             try {
-                BasicBrowser browser = new BasicBrowser(
-                        new MockPreferences(), new ImmediateRunFactory<>(), 2);
+                BasicBrowser browser = new BasicBrowser(new MockPreferences(), 2);
                 BasicBrowser.HtmlTab tab = browser.tabs.get(0);
                 Component source = tab.editorPane;
                 Element sourceElement = tab.kit.createDefaultDocument().getDefaultRootElement();
@@ -195,8 +170,7 @@ class BasicBrowserTest {
     void testLinksHistory() throws InvocationTargetException, InterruptedException {
         SwingUtilities.invokeAndWait(() -> {
             try {
-                BasicBrowser browser = new BasicBrowser(
-                        new MockPreferences(), new ImmediateRunFactory<>(), 3);
+                BasicBrowser browser = new BasicBrowser(new MockPreferences(), 3);
                 BasicBrowser.HtmlTab tab = browser.tabs.get(0);
                 Component source = tab.editorPane;
                 Element sourceElement = tab.kit.createDefaultDocument().getDefaultRootElement();
@@ -210,6 +184,10 @@ class BasicBrowserTest {
                         new MouseEvent(source, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
                                 0, 50, 50, 1, false));
                 tab.hyperlinkUpdate(event);
+                var worker = tab.future;
+                if (worker != null) {
+                    worker.run();
+                }
                 assertLinesMatch(List.of("", url1), tab.history);
                 assertEquals(url1, browser.urlField.getText());
                 assertEquals(1, tab.iHistory);
@@ -221,6 +199,10 @@ class BasicBrowserTest {
                         new MouseEvent(source, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
                                 0, 50, 50, 1, false));
                 tab.hyperlinkUpdate(event);
+                worker = tab.future;
+                if (worker != null) {
+                    worker.run();
+                }
                 assertLinesMatch(List.of("", url1, url2), tab.history);
                 assertEquals(2, tab.iHistory);
                 assertEquals(url2, browser.urlField.getText());
@@ -230,19 +212,39 @@ class BasicBrowserTest {
                         new MouseEvent(source, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
                                 0, 50, 50, 1, false));
                 tab.hyperlinkUpdate(event);
+                worker = tab.future;
+                if (worker != null) {
+                    worker.run();
+                }
                 assertLinesMatch(List.of(url1, url2, url3), tab.history);
                 assertEquals(url3, browser.urlField.getText());
                 assertEquals(2, tab.iHistory);
                 tab.goBack();
+                worker = tab.future;
+                if (worker != null) {
+                    worker.run();
+                }
                 assertEquals(url2, browser.urlField.getText());
                 assertEquals(1, tab.iHistory);
                 tab.goForward();
+                worker = tab.future;
+                if (worker != null) {
+                    worker.run();
+                }
                 assertEquals(url3, browser.urlField.getText());
                 assertEquals(2, tab.iHistory);
                 tab.goBack();
+                worker = tab.future;
+                if (worker != null) {
+                    worker.run();
+                }
                 assertEquals(url2, browser.urlField.getText());
                 assertEquals(1, tab.iHistory);
                 tab.goBack();
+                worker = tab.future;
+                if (worker != null) {
+                    worker.run();
+                }
                 assertEquals(url1, browser.urlField.getText());
                 assertEquals(0, tab.iHistory);
                 event = new HyperlinkEvent(source, HyperlinkEvent.EventType.ACTIVATED,
@@ -250,6 +252,10 @@ class BasicBrowserTest {
                         new MouseEvent(source, MouseEvent.MOUSE_CLICKED, System.currentTimeMillis(),
                                 0, 50, 50, 1, false));
                 tab.hyperlinkUpdate(event);
+                worker = tab.future;
+                if (worker != null) {
+                    worker.run();
+                }
                 assertLinesMatch(List.of(url1, url3), tab.history);
                 assertEquals(url3, browser.urlField.getText());
                 assertEquals(1, tab.iHistory);
@@ -264,16 +270,17 @@ class BasicBrowserTest {
         SwingUtilities.invokeAndWait(() -> {
             try {
                 MockPreferences preferences = new MockPreferences();
-                BasicBrowser browser = new BasicBrowser(
-                        preferences, new ImmediateRunFactory<>(), 3);
+                BasicBrowser browser = new BasicBrowser(preferences, 3);
                 // Add
                 browser.urlField.setText("a http://a.com/q=");
                 browser.changeSearch();
-                assertEquals(BasicBrowser.defaultQuickSearchStr + " a http://a.com/q=", browser.statusField.getText());
+                assertEquals(BasicBrowser.defaultQuickSearchStr + " a http://a.com/q=",
+                        browser.statusField.getText());
                 // Delete
                 browser.urlField.setText("w");
                 browser.changeSearch();
-                assertEquals("http://www.google.com/search?q= a http://a.com/q=", browser.statusField.getText());
+                assertEquals("http://www.google.com/search?q= a http://a.com/q=",
+                        browser.statusField.getText());
                 // Change default
                 browser.urlField.setText("http://b.com/q=");
                 browser.changeSearch();
@@ -282,6 +289,8 @@ class BasicBrowserTest {
                 browser.urlField.setText("a http://c.com/q=");
                 browser.changeSearch();
                 assertEquals("http://b.com/q= a http://c.com/q=", browser.statusField.getText());
+                assertEquals("http://b.com/q= a http://c.com/q=",
+                        preferences.get(BasicBrowser.quickSearchKey, ""));
                 // Try to delete something that doesn't exist
                 browser.urlField.setText("z");
                 browser.changeSearch();
@@ -296,6 +305,8 @@ class BasicBrowserTest {
                 browser.changeSearch();
                 browser.urlField.setText("http://localhost:8001/q=");
                 browser.changeSearch();
+                assertEquals("http://localhost:8001/q= a http://c.com/q= b http://localhost:8000/q=",
+                        preferences.get(BasicBrowser.quickSearchKey, ""));
                 browser.urlField.setText("b test1");
                 browser.urlUpdate(browser.urlField.getText());
                 assertEquals("http://localhost:8000/q=test1", browser.urlField.getText());
@@ -304,7 +315,6 @@ class BasicBrowserTest {
                 assertEquals("http://localhost:8001/q=test2", browser.urlField.getText());
                 browser.urlField.setText("localhost:8000/a");
                 browser.urlUpdate(browser.urlField.getText());
-                assertEquals("http://localhost:8000/a", browser.urlField.getText());
             } catch (MalformedURLException | BackingStoreException e) {
                 e.printStackTrace();
             }
@@ -315,8 +325,7 @@ class BasicBrowserTest {
     void testTabHistory() throws InvocationTargetException, InterruptedException {
         SwingUtilities.invokeAndWait(() -> {
             try {
-                BasicBrowser browser = new BasicBrowser(
-                        new MockPreferences(), new ImmediateRunFactory<>(), 2);
+                BasicBrowser browser = new BasicBrowser(new MockPreferences(), 2);
                 browser.addTab();
                 browser.addTab();
                 browser.addTab();
@@ -347,8 +356,7 @@ class BasicBrowserTest {
     void testBookmarks() throws InvocationTargetException, InterruptedException {
         SwingUtilities.invokeAndWait(() -> {
             try {
-                BasicBrowser browser = new BasicBrowser(
-                        new MockPreferences(), new ImmediateRunFactory<>(), 2);
+                BasicBrowser browser = new BasicBrowser(new MockPreferences(), 2);
                 // Open all bookmarks when none
                 assertEquals(1, browser.tabs.size());
                 JComboBox<String> bookmarkBox = browser.bookmarkBoxes.get(0);
@@ -373,15 +381,29 @@ class BasicBrowserTest {
                 assertEquals(BasicBrowser.openAllStr, bookmarkBox.getItemAt(2));
                 assertEquals(1, browser.tabs.size());
                 // Open bookmark
+                System.out.println("Will open a bookmark");
                 bookmarkBox.setSelectedItem(url1); // will trigger openBookmarkEvent(url1)
+                var worker = browser.tabs.get(0).future;
+                if (worker != null) {
+                    worker.run();
+                }
                 assertEquals(1, browser.tabs.size());
                 assertEquals(url1, browser.urlField.getText());
                 assertEquals(BasicBrowser.exceptionStr.formatted(connectionExceptionStr, url1),
                         browser.statusField.getText());
                 assertEquals(0, browser.iCurrentTab);
                 // Open all bookmarks
+                System.out.println("Will open all bookmarks");
                 bookmarkBox.setSelectedIndex(bookmarkBox.getItemCount() - 1); // will trigger openBookmarkEvent(openAll)
                 assertEquals(BasicBrowser.openAllStr, bookmarkBox.getSelectedItem());
+                worker = browser.tabs.get(1).future;
+                if (worker != null) {
+                    worker.run();
+                }
+                worker = browser.tabs.get(2).future;
+                if (worker != null) {
+                    worker.run();
+                }
                 assertEquals(3, browser.tabs.size());
                 assertEquals(2, browser.iCurrentTab);
                 assertEquals(BasicBrowser.exceptionStr.formatted(connectionExceptionStr, url2),
@@ -401,5 +423,88 @@ class BasicBrowserTest {
                 e.printStackTrace();
             }
         });
+    }
+
+    @Test
+    void testMultipleUrlUpdateError() throws InvocationTargetException, InterruptedException {
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                BasicBrowser browser = new BasicBrowser(new MockPreferences(), 2);
+                BasicBrowser.HtmlTab tab = browser.tabs.get(0);
+                tab.urlUpdate("http://localhost:8000/a", 0);
+                String url = "http://localhost:8001/a";
+                tab.urlUpdate(url, 0);
+                assertEquals(BasicBrowser.futureExistsErrorStr.formatted(url, 0), browser.statusField.getText());
+            } catch (MalformedURLException | BackingStoreException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    // The right way to have the SwingWorker threads finish before checking correctness is to have one
+    // SwingUtilities.invokeAndWait() set everything up, wait a bit for the threads to finish, and then
+    // SwingUtilities.invokeAndWait() to verify that everything is correct. In all the other tests, the
+    // alternative of just calling the worker's run() method works. However, for this test, the more
+    // robust approach needs to be used.
+    volatile BasicBrowser openAllBrowser;
+    @Test
+    void testOpenAll() throws InvocationTargetException, InterruptedException, IOException {
+        int n = 3;
+        File[] files = new File[n];
+        String[] paths = new String[n];
+        String[] bodies = new String[n];
+        for (int i = 0; i < n; i++) {
+            files[i] = File.createTempFile("file", ".html");
+            paths[i] = files[i].getAbsolutePath();
+            FileWriter fw = new FileWriter(files[i]);
+            bodies[i] = "<html><head><title>title %d</title></head><body>body %d</body></html>\n".formatted(
+                    i, i);
+            fw.write(bodies[i]);
+            fw.close();
+        }
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                openAllBrowser = new BasicBrowser(new MockPreferences(), 2);
+                // Open all bookmarks when none
+                assertEquals(1, openAllBrowser.tabs.size());
+                var box = openAllBrowser.bookmarkBoxes.get(0);
+                // Need to use file system files. Since that is not allowed, modify combo box directly.
+                openAllBrowser.addRemoveIsRunning[0] = true;
+                System.out.println("Remove open all.");
+                box.removeItem(BasicBrowser.openAllStr);
+                for (int i = 0; i < n; i++) {
+                    System.out.printf("Adding file %s at index %d\n", paths[i], i);
+                    box.addItem(paths[i]);
+                }
+                System.out.println("Add open all.");
+                box.addItem(BasicBrowser.openAllStr);
+                System.out.println("Done adding to box.");
+                openAllBrowser.addRemoveIsRunning[0] = false;
+                box.setSelectedIndex(box.getItemCount() - 1); // will trigger openBookmarkEvent(openAll)
+                assertEquals(BasicBrowser.openAllStr, box.getSelectedItem());
+                assertEquals(4, openAllBrowser.tabs.size());
+                assertEquals(3, openAllBrowser.iCurrentTab);
+            } catch (BackingStoreException | IOException e) {
+                e.printStackTrace();
+            }
+        });
+        // Give enough time for the SwingWorkers to complete their work before checking output.
+        sleep(2000);
+        SwingUtilities.invokeAndWait(() -> {
+            for (int i = 0; i < n; i++) {
+                System.out.println("Checking assertions at index " + i);
+                assertEquals("title " + i, openAllBrowser.tabs.get(i + 1).getTitle());
+                assertEquals(paths[i], openAllBrowser.tabs.get(i + 1).getUrl());
+                String expected =
+                        "<html>\n  <head>\n    \n  </head>\n  <body>\n    body %d\n  </body>\n</html>\n".formatted(
+                                i);
+                assertEquals(expected, openAllBrowser.tabs.get(i + 1).editorPane.getText());
+            }
+        });
+        for (int i = 0; i < n; i++) {
+            if (!files[i].delete()) {
+                System.out.println("Failed to delete file " + paths[i]);
+            }
+        }
     }
 }


### PR DESCRIPTION
The way that SwingWorker was called was incorrect.

The new approach makes the tests and regular program both use the SwingWorker. Also, the SwingWorker is now called properly to allow opening all benchmarks in one of the benchmark lists to work correctly.

The variable names have been updated to reflect the new approach.

Also, adding and removing benchmarks sometimes caused the open bookmark event to trigger. A flag is added to have this event return right away when this happens.